### PR TITLE
Fix 13 gap audit issues + 7 security hardening fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# ---------------------------------------------------------------------------
+# ControlDesk Operator Web — environment variables
+#
+# Copy this file to .env.local and fill in values for local development.
+# Never commit .env.local or any file containing real secrets.
+# ---------------------------------------------------------------------------
+
+# URL of the Frappe backend server (no trailing slash).
+# In development this is proxied by Vite so the browser never sees it.
+# In production the SPA is typically served from the same origin as Frappe,
+# so this can stay empty — all /api/* calls go to the same host.
+VITE_FRAPPE_URL=http://localhost:8000
+
+# Optional: override the app title shown in the browser tab
+# VITE_APP_TITLE=ControlDesk

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,10 +2,27 @@
 // Base Frappe RPC client
 // ---------------------------------------------------------------------------
 
-import { getAuthHeaders } from "../lib/auth";
+import { getCsrfToken, fetchCsrfToken } from "../lib/auth";
 import type { FrappeResponse } from "../types/api";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+
+/** Default timeout for every API request (30 seconds). */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Session expiry event
+// ---------------------------------------------------------------------------
+// Any module can listen for "controldesk:session-expired" on window to react
+// to a 401 response (e.g. redirect to login).
+
+export function emitSessionExpired(): void {
+  window.dispatchEvent(new CustomEvent("controldesk:session-expired"));
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
 
 export class ApiError extends Error {
   constructor(
@@ -16,6 +33,10 @@ export class ApiError extends Error {
     this.name = "ApiError";
   }
 }
+
+// ---------------------------------------------------------------------------
+// Core fetch helper
+// ---------------------------------------------------------------------------
 
 /**
  * Invoke a Frappe whitelisted RPC method.
@@ -30,33 +51,92 @@ export async function frappeCall<T>(
 ): Promise<T> {
   const url = `${BASE_URL}/api/method/${method}`;
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      ...getAuthHeaders(),
-    },
-    credentials: "include",
-    body: JSON.stringify(params),
-  });
+  // Abort the request after REQUEST_TIMEOUT_MS
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-  if (res.status === 401 || res.status === 403) {
-    throw new ApiError("Unauthorized", res.status);
+  let res: Response;
+
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        // CSRF token required by Frappe for all session-authenticated POSTs
+        "X-Frappe-CSRF-Token": getCsrfToken(),
+      },
+      credentials: "include",
+      body: JSON.stringify(params),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if ((err as Error).name === "AbortError") {
+      throw new ApiError("Request timed out. Please try again.", 408);
+    }
+    throw new ApiError("Network error. Please check your connection.", 0);
+  }
+
+  clearTimeout(timeoutId);
+
+  // 401 — session has expired or was never established
+  if (res.status === 401) {
+    emitSessionExpired();
+    throw new ApiError("Your session has expired. Please sign in again.", 401);
+  }
+
+  // 403 — could be a stale CSRF token; fetch a fresh one and retry once
+  if (res.status === 403) {
+    const freshToken = await fetchCsrfToken();
+    if (freshToken) {
+      // Retry with the refreshed token
+      const retryRes = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-Frappe-CSRF-Token": freshToken,
+        },
+        credentials: "include",
+        body: JSON.stringify(params),
+      });
+
+      if (retryRes.status === 401) {
+        emitSessionExpired();
+        throw new ApiError("Your session has expired. Please sign in again.", 401);
+      }
+
+      if (!retryRes.ok) {
+        throw new ApiError(await extractErrorMessage(retryRes), retryRes.status);
+      }
+
+      const retryBody = (await retryRes.json()) as FrappeResponse<T>;
+      return retryBody.message;
+    }
+
+    throw new ApiError("Permission denied.", 403);
   }
 
   if (!res.ok) {
-    let message = `HTTP ${res.status}`;
-    try {
-      const body = (await res.json()) as { message?: string; exc?: string };
-      if (body.message) message = body.message;
-      else if (body.exc) message = body.exc;
-    } catch {
-      // Could not parse error body — keep the generic message
-    }
-    throw new ApiError(message, res.status);
+    throw new ApiError(await extractErrorMessage(res), res.status);
   }
 
   const body = (await res.json()) as FrappeResponse<T>;
   return body.message;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function extractErrorMessage(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string; exc?: string };
+    if (body.message) return body.message;
+    if (body.exc) return body.exc;
+  } catch {
+    // Response body was not JSON — fall through to generic message
+  }
+  return `HTTP ${res.status}`;
 }

--- a/src/hooks/use-auth-check.ts
+++ b/src/hooks/use-auth-check.ts
@@ -1,15 +1,14 @@
 // ---------------------------------------------------------------------------
-// Simple auth check — calls Frappe's logged_in endpoint
+// Server-side auth check — the single source of truth for session validity
 // ---------------------------------------------------------------------------
 
 import { useQuery } from "@tanstack/react-query";
+import { fetchCsrfToken } from "../lib/auth";
 
-interface LoggedInResponse {
-  message: string; // the user email, or "Guest"
-}
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
 async function checkAuth(): Promise<string> {
-  const res = await fetch("/api/method/frappe.auth.get_logged_user", {
+  const res = await fetch(`${BASE_URL}/api/method/frappe.auth.get_logged_user`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     credentials: "include",
@@ -19,10 +18,14 @@ async function checkAuth(): Promise<string> {
     throw new Error("Not authenticated");
   }
 
-  const data = (await res.json()) as LoggedInResponse;
+  const data = (await res.json()) as { message: string };
   if (!data.message || data.message === "Guest") {
     throw new Error("Not authenticated");
   }
+
+  // Prime the CSRF token cache now that we know the session is valid.
+  // Fire-and-forget — auth check result does not depend on CSRF fetch.
+  void fetchCsrfToken();
 
   return data.message;
 }

--- a/src/hooks/use-session-expiry.ts
+++ b/src/hooks/use-session-expiry.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Session expiry watcher
+//
+// Listens for the "controldesk:session-expired" custom event dispatched by
+// api/client.ts whenever a 401 is received. Redirects the user to /login
+// while preserving the current URL as a `?next=` param so they land back
+// where they were after re-authenticating.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useRef } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { clearCsrfToken } from "../lib/auth";
+
+export function useSessionExpiry(): void {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+
+  // Use a ref so the handler closure always reads the latest location
+  // without needing to be re-registered on every navigation.
+  const locationRef = useRef(location);
+  locationRef.current = location;
+
+  useEffect(() => {
+    let handled = false;
+
+    function handleExpiry() {
+      // Guard against duplicate events from concurrent in-flight requests
+      if (handled) return;
+      handled = true;
+
+      clearCsrfToken();
+      queryClient.clear();
+
+      const returnTo = locationRef.current.pathname + locationRef.current.search;
+      const loginUrl =
+        returnTo && returnTo !== "/" && returnTo !== "/login"
+          ? `/login?next=${encodeURIComponent(returnTo)}`
+          : "/login";
+
+      navigate(loginUrl, { replace: true });
+    }
+
+    window.addEventListener("controldesk:session-expired", handleExpiry);
+    return () => {
+      window.removeEventListener("controldesk:session-expired", handleExpiry);
+    };
+  }, [navigate, queryClient]);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,52 +1,22 @@
 // ---------------------------------------------------------------------------
-// Token storage and session management for Frappe
+// Session management for Frappe — cookie-based, no credentials in localStorage
+//
+// Frappe sets an httpOnly session cookie on successful login. All subsequent
+// requests carry that cookie automatically (credentials: "include"). We do NOT
+// store any credentials or user identity in localStorage; the server is the
+// only source of truth for session validity.
 // ---------------------------------------------------------------------------
 
-const STORAGE_KEY = "controldesk_auth";
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
-interface StoredCredentials {
-  api_key: string;
-  api_secret: string;
-  user: string;
-}
-
-// ---- Credential persistence ----
-
-function readCredentials(): StoredCredentials | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as StoredCredentials;
-  } catch {
-    return null;
-  }
-}
-
-function writeCredentials(creds: StoredCredentials): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(creds));
-}
-
-function clearCredentials(): void {
-  localStorage.removeItem(STORAGE_KEY);
-}
-
-// ---- Public API ----
+// ---------------------------------------------------------------------------
+// Login
+// ---------------------------------------------------------------------------
 
 /**
- * Returns an Authorization header object when token credentials are stored.
- * If the session relies on cookies only, returns an empty object.
- */
-export function getAuthHeaders(): Record<string, string> {
-  const creds = readCredentials();
-  if (!creds) return {};
-  return { Authorization: `token ${creds.api_key}:${creds.api_secret}` };
-}
-
-/**
- * Log in via Frappe's built-in login endpoint.
- * On success Frappe sets session cookies; we also store the user identifier
- * so that `getCurrentUser()` works without an extra round-trip.
+ * Authenticate against Frappe's built-in login endpoint.
+ * On success Frappe sets a session cookie; no credentials are persisted
+ * on the client.
  */
 export async function login(
   email: string,
@@ -54,65 +24,99 @@ export async function login(
 ): Promise<{ user: string }> {
   const res = await fetch(`${BASE_URL}/api/method/login`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
     credentials: "include",
     body: JSON.stringify({ usr: email, pwd: password }),
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(
-      (body as Record<string, string>).message ?? "Login failed",
-    );
+    const body = await res.json().catch(() => ({})) as Record<string, string>;
+    throw new Error(body.message ?? "Login failed. Please check your credentials.");
   }
 
   const data = (await res.json()) as { message: string; full_name?: string };
 
-  // Frappe responds with the user email in `message` on success
+  // Frappe responds with "Logged In" in `message` on success
   const user = data.message === "Logged In" ? email : data.message;
-
-  // Persist minimally so getCurrentUser works across refreshes
-  writeCredentials({ api_key: "", api_secret: "", user });
-
   return { user };
 }
 
-/**
- * Store explicit API key / secret credentials (e.g. from a settings page).
- */
-export function setTokenCredentials(
-  apiKey: string,
-  apiSecret: string,
-  user: string,
-): void {
-  writeCredentials({ api_key: apiKey, api_secret: apiSecret, user });
-}
+// ---------------------------------------------------------------------------
+// Logout
+// ---------------------------------------------------------------------------
 
 /**
- * Log out of the current Frappe session and clear stored credentials.
+ * Terminate the current Frappe session.
+ * The CSRF token is included so the backend accepts the POST.
  */
 export async function logout(): Promise<void> {
+  await fetch(`${BASE_URL}/api/method/logout`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-Frappe-CSRF-Token": getCsrfToken(),
+    },
+    credentials: "include",
+  }).catch(() => {
+    // Best-effort — even if the network call fails, the client-side
+    // cleanup below will run so the user is redirected to login.
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CSRF token — in-memory only, never persisted
+// ---------------------------------------------------------------------------
+//
+// Frappe embeds csrf_token in the HTML it serves. For a standalone SPA
+// we fetch it once after login from a lightweight bootstrap GET, then cache
+// it in a module-level variable for the lifetime of the page.
+//
+// Rotation: if any request receives a 403 we call refreshCsrfToken() to
+// re-fetch and retry (handled in api/client.ts).
+
+let _csrfToken = "";
+
+/** Return the cached CSRF token (empty string if not yet fetched). */
+export function getCsrfToken(): string {
+  return _csrfToken;
+}
+
+/** Store a new CSRF token (called by the API client on 403 retry). */
+export function setCsrfToken(token: string): void {
+  _csrfToken = token;
+}
+
+/**
+ * Fetch the CSRF token from Frappe and cache it.
+ *
+ * Frappe embeds `csrf_token = "…"` in its HTML shell. When the SPA is served
+ * through Frappe (the normal production setup) we parse it from the page body.
+ * In dev (Vite proxy) we fall back to an unauthenticated GET that returns a
+ * minimal HTML fragment containing the token.
+ */
+export async function fetchCsrfToken(): Promise<string> {
   try {
-    await fetch(`${BASE_URL}/api/method/logout`, {
-      method: "POST",
+    const res = await fetch(`${BASE_URL}/`, {
+      method: "GET",
       credentials: "include",
+      headers: { Accept: "text/html" },
     });
-  } finally {
-    clearCredentials();
+    const html = await res.text();
+    // Frappe injects:  csrf_token = "abc123"
+    const match = html.match(/csrf_token\s*=\s*["']([^"']{10,})["']/);
+    if (match?.[1]) {
+      _csrfToken = match[1];
+      return _csrfToken;
+    }
+  } catch {
+    // Non-fatal — requests will proceed without CSRF header and the backend
+    // will reject them with 403 if it requires the token, triggering a retry.
   }
+  return _csrfToken;
 }
 
-/**
- * Whether the client believes there is an active session.
- * This is a client-side heuristic only; the server may have expired the session.
- */
-export function isAuthenticated(): boolean {
-  return readCredentials() !== null;
-}
-
-/**
- * Return the email of the currently stored user, or `null` if not authenticated.
- */
-export function getCurrentUser(): string | null {
-  return readCredentials()?.user ?? null;
+/** Clear the cached CSRF token (on logout). */
+export function clearCsrfToken(): void {
+  _csrfToken = "";
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { cn } from "../lib/cn";
-import { login } from "../lib/auth";
+import { login, fetchCsrfToken } from "../lib/auth";
 import { Input } from "../components/primitives/Input";
 import { Button } from "../components/primitives/Button";
 
@@ -28,9 +28,14 @@ export default function LoginPage() {
 
       try {
         await login(email, password);
-        // Clear all cached queries so bootstrap re-fetches with new session
+        // Prime CSRF token before any authenticated API calls are made
+        await fetchCsrfToken();
+        // Clear all cached queries so bootstrap re-fetches with the new session
         queryClient.clear();
-        navigate("/", { replace: true });
+        // Honour redirect-after-login if present in the URL (?next=/queue/…)
+        const params = new URLSearchParams(window.location.search);
+        const next = params.get("next");
+        navigate(next && next.startsWith("/") ? next : "/", { replace: true });
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "An unexpected error occurred",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,12 +2,16 @@
 // SettingsPage — route: /settings
 // ---------------------------------------------------------------------------
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { LogOut, Monitor, Sun, Moon } from "lucide-react";
 import { cn } from "../lib/cn";
+import { logout, clearCsrfToken } from "../lib/auth";
 import { useTheme } from "../hooks/use-theme";
 import { useUIStore } from "../stores/ui-store";
 import { useRoleGate } from "../hooks/use-role-gate";
+import { useAuthCheck } from "../hooks/use-auth-check";
 import {
   KEYBOARD_SHORTCUTS,
   type ShortcutScope,
@@ -107,15 +111,26 @@ function SettingsSection({
 /* ------------------------------------------------------------------ */
 
 export default function SettingsPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { theme, setTheme } = useTheme();
   const { rowDensity, setRowDensity, sidebarCollapsed, toggleSidebar } =
     useUIStore();
   const { userRoles } = useRoleGate();
+  const { data: currentUser } = useAuthCheck();
+  const [signingOut, setSigningOut] = useState(false);
 
-  const handleSignOut = useCallback(() => {
-    // In production, redirect to /api/method/logout
-    window.location.href = "/api/method/logout";
-  }, []);
+  const handleSignOut = useCallback(async () => {
+    setSigningOut(true);
+    try {
+      await logout();
+    } finally {
+      // Always clean up client-side state, even if the network call failed
+      clearCsrfToken();
+      queryClient.clear();
+      navigate("/login", { replace: true });
+    }
+  }, [navigate, queryClient]);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -249,21 +264,10 @@ export default function SettingsPage() {
             <div className="flex justify-between gap-4">
               <div>
                 <p className="text-[length:var(--text-small-size)] font-medium text-fg-default">
-                  Display name
-                </p>
-                <p className="text-[length:var(--text-small-size)] text-fg-muted">
-                  Operator User
-                </p>
-              </div>
-            </div>
-
-            <div className="flex justify-between gap-4">
-              <div>
-                <p className="text-[length:var(--text-small-size)] font-medium text-fg-default">
                   Email
                 </p>
                 <p className="text-[length:var(--text-small-size)] text-fg-muted">
-                  operator@controldesk.app
+                  {currentUser ?? "—"}
                 </p>
               </div>
             </div>
@@ -291,9 +295,10 @@ export default function SettingsPage() {
               <Button
                 variant="danger"
                 icon={LogOut}
-                onClick={handleSignOut}
+                disabled={signingOut}
+                onClick={() => void handleSignOut()}
               >
-                Sign out
+                {signingOut ? "Signing out…" : "Sign out"}
               </Button>
             </div>
           </div>

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from "../components/patterns/CommandPalette";
 import { Spinner } from "../components/primitives/Spinner";
 import { useUIStore } from "../stores/ui-store";
 import { useAuthCheck } from "../hooks/use-auth-check";
+import { useSessionExpiry } from "../hooks/use-session-expiry";
 
 function PageFallback() {
   return (
@@ -21,6 +22,9 @@ function PageFallback() {
 export function AppShell() {
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
   const { data: user, isLoading, isError } = useAuthCheck();
+
+  // Redirect to /login (with ?next=) whenever any API call returns 401
+  useSessionExpiry();
 
   // Redirect to login if not authenticated
   if (isError || (!isLoading && !user)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,26 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
-  plugins: [tailwindcss(), react()],
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://206.189.128.22:8000",
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const frappeUrl = env.VITE_FRAPPE_URL ?? "http://localhost:8000";
+
+  return {
+    plugins: [tailwindcss(), react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: frappeUrl,
+          changeOrigin: true,
+        },
       },
     },
-  },
-  test: {
-    environment: "jsdom",
-    globals: true,
-    setupFiles: "./src/test/setup.ts",
-    css: false,
-  },
+    test: {
+      environment: "jsdom",
+      globals: true,
+      setupFiles: "./src/test/setup.ts",
+      css: false,
+    },
+  };
 });


### PR DESCRIPTION
## Summary

Two batches of work from the gap audit:

### Batch 1 — Gap audit fixes (13 issues)
- **Critical**: Route config/router mismatch, role-based redirect, bulk action stubs, LoginPage Suspense crash, Add Note non-functional
- **Major**: Global ErrorBoundary, AccessDenied route, refetchInterval for queue polling, URL-synced filter state, prefers-reduced-motion CSS
- **Minor**: useKeyboard ref pattern (no re-registration), aria-live on toast viewport, theme FOUC blocking script

### Batch 2 — Security hardening (S1–S7)
- Remove hardcoded server IP from `vite.config.ts` → `VITE_FRAPPE_URL` env var + `.env.example`
- Remove all localStorage credential storage — session is purely cookie-based
- Add `X-Frappe-CSRF-Token` to every API request, with auto-refresh on 403
- Fix logout: sends CSRF token, clears React Query cache, navigates via router (no `window.location.href`)
- Add `useSessionExpiry` hook: any 401 dispatches a custom event → redirects to `/login?next=<return-url>`
- Redirect-after-login honours the `?next=` param
- 30-second `AbortController` timeout on every `frappeCall()`

## Test plan
- [ ] Login → verify no localStorage entries written
- [ ] Navigate to a protected page → expire session manually (clear cookies) → verify redirect to `/login?next=<path>` → re-login → verify return to original page
- [ ] Trigger a bulk action → verify toast feedback
- [ ] Open app with no `VITE_FRAPPE_URL` set → verify it proxies to localhost:8000
- [ ] Check TypeScript: `tsc --noEmit` passes with 0 errors
- [ ] Check build: `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)