### PR TITLE
Auth: route guard, open-redirect fix, session polling, error handling (A1-A5)

### DIFF
--- a/src/hooks/use-auth-check.ts
+++ b/src/hooks/use-auth-check.ts
@@ -7,13 +7,55 @@ import { fetchCsrfToken } from "../lib/auth";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
-async function checkAuth(): Promise<string> {
-  const res = await fetch(`${BASE_URL}/api/method/frappe.auth.get_logged_user`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
-    credentials: "include",
-  });
+// ---------------------------------------------------------------------------
+// Error sentinel — distinguishes backend unavailability from auth failure
+// ---------------------------------------------------------------------------
 
+/**
+ * Thrown when the auth endpoint itself is unreachable or returns a 5xx.
+ * AppShell checks for this type to show a "service unavailable" banner
+ * instead of redirecting to /login (which would also fail).
+ */
+export class AuthServiceUnavailableError extends Error {
+  constructor(status: number) {
+    super(
+      status === 0
+        ? "Could not reach the authentication service. Check your network connection."
+        : `Authentication service is unavailable (HTTP ${status}). Please try again later.`,
+    );
+    this.name = "AuthServiceUnavailableError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query function
+// ---------------------------------------------------------------------------
+
+async function checkAuth(): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetch(
+      `${BASE_URL}/api/method/frappe.auth.get_logged_user`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        credentials: "include",
+      },
+    );
+  } catch {
+    // Network-level failure (DNS, connection refused, offline)
+    throw new AuthServiceUnavailableError(0);
+  }
+
+  // 5xx → service problem, not an auth failure
+  if (res.status >= 500) {
+    throw new AuthServiceUnavailableError(res.status);
+  }
+
+  // 4xx (401, 403, 404) → not authenticated
   if (!res.ok) {
     throw new Error("Not authenticated");
   }
@@ -30,11 +72,22 @@ async function checkAuth(): Promise<string> {
   return data.message;
 }
 
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useAuthCheck() {
   return useQuery<string, Error>({
     queryKey: ["auth-check"],
     queryFn: checkAuth,
     staleTime: 60_000,
-    retry: false,
+    // Retry once on transient failures; skip retry for auth/service errors.
+    retry: (failureCount, err) =>
+      !(err instanceof AuthServiceUnavailableError) &&
+      err.message !== "Not authenticated" &&
+      failureCount < 1,
+    // Poll every 5 minutes so session expiry is detected proactively rather
+    // than only when the next real API call happens to return 401.
+    refetchInterval: 5 * 60 * 1000,
   });
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -32,10 +32,14 @@ export default function LoginPage() {
         await fetchCsrfToken();
         // Clear all cached queries so bootstrap re-fetches with the new session
         queryClient.clear();
-        // Honour redirect-after-login if present in the URL (?next=/queue/…)
+        // Honour redirect-after-login if present in the URL (?next=/queue/…).
+        // Only allow same-origin relative paths; block protocol-relative URLs
+        // (//attacker.com) which could bypass the startsWith("/") check.
         const params = new URLSearchParams(window.location.search);
         const next = params.get("next");
-        navigate(next && next.startsWith("/") ? next : "/", { replace: true });
+        const isSafeRedirect =
+          !!next && next.startsWith("/") && !next.startsWith("//");
+        navigate(isSafeRedirect ? next : "/", { replace: true });
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "An unexpected error occurred",

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { cn } from "../lib/cn";
 import { TooltipProvider } from "../components/primitives/Tooltip";
 import { ToastProvider } from "../components/patterns/NotificationToast";
@@ -7,8 +7,9 @@ import { TopBar } from "../components/patterns/TopBar";
 import { Sidebar } from "../components/patterns/Sidebar";
 import { CommandPalette } from "../components/patterns/CommandPalette";
 import { Spinner } from "../components/primitives/Spinner";
+import { Button } from "../components/primitives/Button";
 import { useUIStore } from "../stores/ui-store";
-import { useAuthCheck } from "../hooks/use-auth-check";
+import { useAuthCheck, AuthServiceUnavailableError } from "../hooks/use-auth-check";
 import { useSessionExpiry } from "../hooks/use-session-expiry";
 
 function PageFallback() {
@@ -20,24 +21,54 @@ function PageFallback() {
 }
 
 export function AppShell() {
+  const location = useLocation();
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
-  const { data: user, isLoading, isError } = useAuthCheck();
+  const { data: user, isLoading, isError, error } = useAuthCheck();
 
   // Redirect to /login (with ?next=) whenever any API call returns 401
   useSessionExpiry();
 
-  // Redirect to login if not authenticated
-  if (isError || (!isLoading && !user)) {
-    return <Navigate to="/login" replace />;
-  }
-
-  // Show loading spinner while checking auth
+  // Show full-screen spinner while the initial auth check is in flight
   if (isLoading) {
     return (
       <div className="flex min-h-dvh items-center justify-center bg-bg-app">
         <Spinner size="lg" />
       </div>
     );
+  }
+
+  // If the auth service itself is down (5xx / network), show an error banner
+  // rather than redirecting to /login — login would fail too.
+  if (isError && error instanceof AuthServiceUnavailableError) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-bg-app px-4 text-center">
+        <p
+          className={cn(
+            "text-[length:var(--text-small-size)] leading-[var(--text-small-leading)]",
+            "text-fg-muted max-w-sm",
+          )}
+        >
+          {error.message}
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => window.location.reload()}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  // Not authenticated — redirect to /login preserving the attempted URL
+  if (isError || !user) {
+    const returnTo = location.pathname + location.search;
+    const loginPath =
+      returnTo && returnTo !== "/" && returnTo !== "/login"
+        ? `/login?next=${encodeURIComponent(returnTo)}`
+        : "/login";
+    return <Navigate to={loginPath} replace />;
   }
 
   return (


### PR DESCRIPTION
## Summary

- **A1** — AppShell unauthenticated redirect now includes `?next=<current-path>`, so users land back on the page they were trying to reach after logging in (previously just redirected to `/login` with no return path)
- **A2** — LoginPage `?next=` redirect blocks protocol-relative URLs (`//attacker.com`) that bypassed the `startsWith("/")` check; guard is now `startsWith("/") && !startsWith("//")`
- **A3** — `useAuthCheck` polls every 5 minutes via `refetchInterval: 5 * 60 * 1000`, detecting session expiry proactively rather than only when the next real API call happens to return 401
- **A4** — `checkAuth` now distinguishes network/5xx failures (`AuthServiceUnavailableError`) from actual auth failures; AppShell shows a "service unavailable" + Retry banner instead of redirecting to `/login` when the auth endpoint itself is down (login would fail anyway)
- **A5** — Confirmed: full-screen spinner in AppShell during `isLoading` already covers the loading-splash requirement; no further change needed

## Test plan

- [ ] Navigate to `/queue/my-queue` unauthenticated → redirected to `/login?next=%2Fqueue%2Fmy-queue` → after login lands back on queue page
- [ ] `?next=//evil.com` in login URL → ignored, redirects to `/` instead
- [ ] With DevTools network throttle → AppShell polls every 5 minutes (check Network tab for periodic `get_logged_user` requests)
- [ ] Simulate auth endpoint 503 (block the request in DevTools) → "service unavailable" banner with Retry button appears instead of being sent to `/login`
- [ ] TypeScript: `npx tsc --noEmit` passes clean
- [ ] Production build: `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)