### PR TITLE
Features: owner filter, CSV export, shortcuts modal, global keybindings (F2/F3/F8/F10)

### DIFF
--- a/src/components/patterns/FilterBar.tsx
+++ b/src/components/patterns/FilterBar.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useCallback } from "react";
-import { Plus, Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { cn } from "../../lib/cn";
 import { Button } from "../primitives/Button";
 import { Select } from "../primitives/Select";
@@ -21,36 +21,38 @@ export interface FilterBarProps {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Debounced search sub-component                                     */
+/*  Debounced text input sub-component                                 */
 /* ------------------------------------------------------------------ */
 
 /**
- * Isolated search input that maintains its own local state.
- * When the parent `value` changes the component re-mounts via `key`
- * (handled by the parent) to reset the local value.
+ * Generic debounced text input. Maintains its own local state so every
+ * keystroke does not trigger a re-render of the parent. Parent resets
+ * the input via `key` prop when the external value changes.
  */
-function DebouncedSearch({
+function DebouncedInput({
   initialValue,
-  onSearch,
+  onCommit,
+  placeholder,
+  className,
+  icon: Icon,
 }: {
   initialValue: string;
-  onSearch: (value: string) => void;
+  onCommit: (value: string) => void;
+  placeholder: string;
+  className?: string;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => {
-        onSearch(value);
-      }, 300);
+      timerRef.current = setTimeout(() => onCommit(value), 300);
     },
-    [onSearch],
+    [onCommit],
   );
 
-  // Cleanup debounce on unmount
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
@@ -58,18 +60,20 @@ function DebouncedSearch({
   }, []);
 
   return (
-    <div className="relative w-[200px]">
-      <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5">
-        <Search size={14} className="text-fg-faint" aria-hidden="true" />
-      </span>
+    <div className={cn("relative", className ?? "w-[180px]")}>
+      {Icon && (
+        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5">
+          <Icon size={14} className="text-fg-faint" />
+        </span>
+      )}
       <input
-        ref={inputRef}
         type="search"
-        placeholder="Search..."
+        placeholder={placeholder}
         defaultValue={initialValue}
         onChange={handleChange}
         className={cn(
-          "h-8 w-full rounded-[var(--radius-md)] border border-border-default bg-bg-surface pl-8 pr-3",
+          "h-8 w-full rounded-[var(--radius-md)] border border-border-default bg-bg-surface pr-3",
+          Icon ? "pl-8" : "pl-3",
           "text-[length:var(--text-small-size)] text-fg-default placeholder:text-fg-faint",
           "outline-none transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
           "focus-visible:border-[var(--ring-focus)] focus-visible:shadow-[var(--shadow-focus)]",
@@ -96,6 +100,13 @@ export function FilterBar({
     [filters, onFiltersChange],
   );
 
+  const handleOwner = useCallback(
+    (value: string) => {
+      onFiltersChange({ ...filters, owner: value || undefined });
+    },
+    [filters, onFiltersChange],
+  );
+
   // Collect active filter chips
   const chips: { key: string; label: string; value: string }[] = [];
   if (filters.status) chips.push({ key: "status", label: "Status", value: filters.status });
@@ -112,6 +123,10 @@ export function FilterBar({
     else if (key === "escalation") next.escalation_state = undefined;
     else if (key === "overdue") next.only_overdue = undefined;
     onFiltersChange(next);
+  }
+
+  function clearAllFilters() {
+    onFiltersChange({});
   }
 
   const escalationOptions = ALL_ESCALATION_STATES.map((s) => ({
@@ -140,7 +155,7 @@ export function FilterBar({
             onValueChange={(v) =>
               onFiltersChange({ ...filters, status: v || undefined })
             }
-            className="w-[150px]"
+            className="w-[140px]"
           />
         )}
 
@@ -155,6 +170,15 @@ export function FilterBar({
               escalation_state: (v as EscalationState) || undefined,
             })
           }
+          className="w-[140px]"
+        />
+
+        {/* Owner filter — debounced text search */}
+        <DebouncedInput
+          key={filters.owner ?? "owner"}
+          initialValue={filters.owner ?? ""}
+          onCommit={handleOwner}
+          placeholder="Owner..."
           className="w-[150px]"
         />
 
@@ -170,25 +194,35 @@ export function FilterBar({
           }
         />
 
-        {/* Add filter button (placeholder for future filters) */}
-        <Button variant="ghost" size="sm" icon={Plus}>
-          Filter
-        </Button>
+        {/* Clear all — visible only when at least one filter is active */}
+        {chips.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={X}
+            onClick={clearAllFilters}
+          >
+            Clear
+          </Button>
+        )}
 
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Debounced search input — key resets when external value changes */}
-        <DebouncedSearch
-          key={filters.search_text ?? ""}
+        {/* Debounced search input */}
+        <DebouncedInput
+          key={filters.search_text ?? "search"}
           initialValue={filters.search_text ?? ""}
-          onSearch={handleSearch}
+          onCommit={handleSearch}
+          placeholder="Search..."
+          className="w-[200px]"
+          icon={Search}
         />
 
         {/* Count display */}
         {totalCount != null && (
           <span className="text-[length:var(--text-caption-size)] text-fg-muted whitespace-nowrap">
-            Showing {totalCount} items
+            {totalCount.toLocaleString()} items
           </span>
         )}
       </div>

--- a/src/components/patterns/QueueList.tsx
+++ b/src/components/patterns/QueueList.tsx
@@ -7,7 +7,7 @@ import {
   createColumnHelper,
   type SortingState,
 } from "@tanstack/react-table";
-import { ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
+import { ArrowUp, ArrowDown, ChevronsUpDown, Download } from "lucide-react";
 import { ACTION_KEYS } from "../../config/action-keys";
 import { cn } from "../../lib/cn";
 import { useQueueRows } from "../../hooks/use-queue-rows";
@@ -61,6 +61,35 @@ function SortIcon({ direction }: { direction: false | "asc" | "desc" }) {
 /* ------------------------------------------------------------------ */
 
 const columnHelper = createColumnHelper<QueueRowType>();
+
+/* ------------------------------------------------------------------ */
+/*  CSV export helper                                                  */
+/* ------------------------------------------------------------------ */
+
+function exportToCsv(rows: QueueRowType[], filename: string) {
+  const headers = ["ID", "Title", "Status", "Owner", "Due Date"];
+  const escape = (v: string | null | undefined) => {
+    const s = String(v ?? "");
+    return s.includes(",") || s.includes('"') || s.includes("\n")
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
+  };
+  const lines = [
+    headers.join(","),
+    ...rows.map((r) =>
+      [r.docname, r.title, r.status, r.current_owner, r.target_date]
+        .map(escape)
+        .join(","),
+    ),
+  ];
+  const blob = new Blob([lines.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
@@ -394,6 +423,20 @@ export function QueueList({
           <span className="text-[length:var(--text-caption-size)] text-fg-muted">
             {totalCount} total
           </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={Download}
+            onClick={() =>
+              exportToCsv(
+                rows,
+                `${queueKey}-${new Date().toISOString().slice(0, 10)}.csv`,
+              )
+            }
+            aria-label="Export to CSV"
+          >
+            Export
+          </Button>
           <select
             className={cn(
               "h-7 rounded-[var(--radius-sm)] border border-border-default bg-bg-surface px-2",

--- a/src/components/patterns/ShortcutsModal.tsx
+++ b/src/components/patterns/ShortcutsModal.tsx
@@ -1,0 +1,162 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/cn";
+import { Button } from "../primitives/Button";
+import {
+  KEYBOARD_SHORTCUTS,
+  type ShortcutScope,
+} from "../../config/keyboard-shortcuts";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Format a hotkey string into human-readable key badges. */
+function formatKey(key: string): string[] {
+  const isMac =
+    typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+
+  return key.split("+").map((k) => {
+    if (k === "mod") return isMac ? "⌘" : "Ctrl";
+    if (k === "shift") return "⇧";
+    if (k === "alt") return isMac ? "⌥" : "Alt";
+    if (k === "enter") return "↵";
+    if (k === "escape") return "Esc";
+    if (k === "space") return "Space";
+    return k.toUpperCase();
+  });
+}
+
+const SCOPE_LABELS: Record<ShortcutScope, string> = {
+  global: "Global",
+  queue: "Queue",
+  detail: "Case Detail",
+};
+
+const SCOPE_ORDER: ShortcutScope[] = ["global", "queue", "detail"];
+
+/* ------------------------------------------------------------------ */
+/*  Key badge                                                          */
+/* ------------------------------------------------------------------ */
+
+function KeyBadge({ label }: { label: string }) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex items-center justify-center",
+        "min-w-[24px] rounded-[var(--radius-sm)] border border-border-default",
+        "bg-bg-surface px-1.5 py-0.5",
+        "font-mono text-[length:var(--text-caption-size)] text-fg-muted",
+      )}
+    >
+      {label}
+    </kbd>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Props                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface ShortcutsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function ShortcutsModal({ open, onOpenChange }: ShortcutsModalProps) {
+  const byScope = new Map<ShortcutScope, typeof KEYBOARD_SHORTCUTS>();
+  for (const shortcut of KEYBOARD_SHORTCUTS) {
+    const list = byScope.get(shortcut.scope) ?? [];
+    list.push(shortcut);
+    byScope.set(shortcut.scope, list);
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-[rgba(0,0,0,0.48)]",
+            "animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+            "duration-[var(--duration-fast)]",
+          )}
+        />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
+            "w-full max-w-lg max-h-[80vh]",
+            "bg-bg-default border border-border-default",
+            "rounded-[var(--radius-lg)] shadow-lg",
+            "flex flex-col",
+            "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+            "duration-[var(--duration-fast)]",
+            "focus:outline-none",
+          )}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border-default px-5 py-3.5">
+            <Dialog.Title
+              className={cn(
+                "text-[length:var(--text-body-size)] font-[number:var(--text-body-medium-weight)]",
+                "text-fg-default",
+              )}
+            >
+              Keyboard Shortcuts
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <Button variant="icon" size="sm" aria-label="Close">
+                <X size={16} aria-hidden="true" />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          {/* Body — scrollable */}
+          <div className="overflow-y-auto px-5 py-4 space-y-6">
+            {SCOPE_ORDER.map((scope) => {
+              const shortcuts = byScope.get(scope);
+              if (!shortcuts?.length) return null;
+              return (
+                <section key={scope}>
+                  <h2
+                    className={cn(
+                      "mb-2 text-[length:var(--text-caption-size)] font-semibold uppercase tracking-wider",
+                      "text-fg-faint",
+                    )}
+                  >
+                    {SCOPE_LABELS[scope]}
+                  </h2>
+                  <div className="divide-y divide-border-default">
+                    {shortcuts.map((s) => (
+                      <div
+                        key={s.key}
+                        className="flex items-center justify-between gap-4 py-2"
+                      >
+                        <span
+                          className={cn(
+                            "text-[length:var(--text-small-size)] leading-[var(--text-small-leading)]",
+                            "text-fg-default",
+                          )}
+                        >
+                          {s.label}
+                        </span>
+                        <div className="flex shrink-0 items-center gap-1">
+                          {formatKey(s.key).map((k, i) => (
+                            <KeyBadge key={i} label={k} />
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -17,6 +17,9 @@ export interface UIState {
 
   previewOpen: boolean;
   setPreviewOpen: (open: boolean) => void;
+
+  shortcutsOpen: boolean;
+  setShortcutsOpen: (open: boolean) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -34,6 +37,9 @@ export const useUIStore = create<UIState>()(
 
       previewOpen: false,
       setPreviewOpen: (previewOpen) => set({ previewOpen }),
+
+      shortcutsOpen: false,
+      setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
     }),
     {
       name: "controldesk-ui",

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,14 +1,16 @@
 import { Suspense } from "react";
-import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { Navigate, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { cn } from "../lib/cn";
 import { TooltipProvider } from "../components/primitives/Tooltip";
 import { ToastProvider } from "../components/patterns/NotificationToast";
 import { TopBar } from "../components/patterns/TopBar";
 import { Sidebar } from "../components/patterns/Sidebar";
 import { CommandPalette } from "../components/patterns/CommandPalette";
+import { ShortcutsModal } from "../components/patterns/ShortcutsModal";
 import { Spinner } from "../components/primitives/Spinner";
 import { Button } from "../components/primitives/Button";
 import { useUIStore } from "../stores/ui-store";
+import { useKeyboard } from "../hooks/use-keyboard";
 import { useAuthCheck, AuthServiceUnavailableError } from "../hooks/use-auth-check";
 import { useSessionExpiry } from "../hooks/use-session-expiry";
 
@@ -22,11 +24,22 @@ function PageFallback() {
 
 export function AppShell() {
   const location = useLocation();
+  const navigate = useNavigate();
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
+  const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const shortcutsOpen = useUIStore((s) => s.shortcutsOpen);
+  const setShortcutsOpen = useUIStore((s) => s.setShortcutsOpen);
   const { data: user, isLoading, isError, error } = useAuthCheck();
 
   // Redirect to /login (with ?next=) whenever any API call returns 401
   useSessionExpiry();
+
+  // Global keyboard shortcuts
+  useKeyboard([
+    { key: "mod+b", handler: toggleSidebar },
+    { key: "mod+,", handler: () => navigate("/settings") },
+    { key: "mod+/", handler: () => setShortcutsOpen(true) },
+  ]);
 
   // Show full-screen spinner while the initial auth check is in flight
   if (isLoading) {
@@ -105,8 +118,12 @@ export function AppShell() {
             </main>
           </div>
 
-          {/* Command palette (global overlay) */}
+          {/* Global overlays */}
           <CommandPalette />
+          <ShortcutsModal
+            open={shortcutsOpen}
+            onOpenChange={setShortcutsOpen}
+          />
         </div>
       </ToastProvider>
     </TooltipProvider>


### PR DESCRIPTION
## Summary

- **F2 — Owner filter**: `FilterBar` now has a debounced owner text input alongside the existing status/escalation selectors; it's URL-synced via `useUrlFilters` so it survives refresh; a "Clear all" button appears when any filter chip is active, replacing the non-functional placeholder button
- **F3 — Global keyboard shortcuts wired**: `AppShell` now registers three previously documented-but-unimplemented shortcuts: `mod+b` → toggle sidebar, `mod+,` → navigate to Settings, `mod+/` → open shortcuts modal
- **F8 — Keyboard shortcuts modal**: New `ShortcutsModal` component shows all `KEYBOARD_SHORTCUTS` grouped by scope (Global / Queue / Case Detail) with formatted key badges (⌘/Ctrl, ⇧, etc.); state stored in `ui-store`; triggered by `mod+/`
- **F10 — CSV export**: QueueList pagination footer has an "Export" button that downloads all currently filtered rows (not just the visible page) as a properly escaped CSV with columns: ID, Title, Status, Owner, Due Date

## Test plan

- [ ] Type an owner name in the new filter input → URL updates with `?owner=...` and rows filter; chip appears and removes the filter on click
- [ ] Activate any filter, then click "Clear" → all filters reset at once
- [ ] Press `mod+b` → sidebar collapses/expands
- [ ] Press `mod+,` → navigates to `/settings`
- [ ] Press `mod+/` → keyboard shortcuts modal opens with all shortcut groups; `Esc` / clicking outside closes it
- [ ] Click "Export" in queue footer → browser downloads a `.csv` file with all rows (including rows on other pages); file is valid CSV
- [ ] TypeScript: `npx tsc --noEmit` passes clean
- [ ] Production build: `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)