### PR TITLE
Accessibility: ARIA, keyboard nav, live regions, table semantics (AC1-AC7)

### DIFF
--- a/src/components/patterns/ActivityTimeline.tsx
+++ b/src/components/patterns/ActivityTimeline.tsx
@@ -91,6 +91,7 @@ function FilterChipButton({
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active}
       className={cn(
         "px-2.5 py-1",
         "text-[length:var(--text-caption-size)] leading-[var(--text-caption-leading)]",

--- a/src/components/patterns/FilterBar.tsx
+++ b/src/components/patterns/FilterBar.tsx
@@ -33,12 +33,14 @@ function DebouncedInput({
   initialValue,
   onCommit,
   placeholder,
+  ariaLabel,
   className,
   icon: Icon,
 }: {
   initialValue: string;
   onCommit: (value: string) => void;
   placeholder: string;
+  ariaLabel: string;
   className?: string;
   icon?: React.ComponentType<{ size?: number; className?: string }>;
 }) {
@@ -69,6 +71,7 @@ function DebouncedInput({
       <input
         type="search"
         placeholder={placeholder}
+        aria-label={ariaLabel}
         defaultValue={initialValue}
         onChange={handleChange}
         className={cn(
@@ -179,6 +182,7 @@ export function FilterBar({
           initialValue={filters.owner ?? ""}
           onCommit={handleOwner}
           placeholder="Owner..."
+          ariaLabel="Filter by owner"
           className="w-[150px]"
         />
 
@@ -215,6 +219,7 @@ export function FilterBar({
           initialValue={filters.search_text ?? ""}
           onCommit={handleSearch}
           placeholder="Search..."
+          ariaLabel="Search queue items"
           className="w-[200px]"
           icon={Search}
         />

--- a/src/components/patterns/QueueList.tsx
+++ b/src/components/patterns/QueueList.tsx
@@ -326,7 +326,7 @@ export function QueueList({
   // Loading state
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-0.5">
+      <div role="status" aria-live="polite" aria-label="Loading queue items" className="flex flex-col gap-0.5">
         {Array.from({ length: 8 }).map((_, i) => (
           <Skeleton key={i} variant="row" />
         ))}
@@ -348,10 +348,12 @@ export function QueueList({
   // Empty state
   if (rows.length === 0) {
     return (
-      <EmptyState
-        title="No items in queue"
-        description="There are no items matching your current filters."
-      />
+      <div role="status" aria-live="polite">
+        <EmptyState
+          title="No items in queue"
+          description="There are no items matching your current filters."
+        />
+      </div>
     );
   }
 
@@ -359,7 +361,7 @@ export function QueueList({
     <div className="flex flex-col">
       {/* Table */}
       <div className="overflow-x-auto">
-        <table className="w-full border-collapse">
+        <table className="w-full border-collapse" aria-label="Queue items">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr
@@ -368,9 +370,19 @@ export function QueueList({
               >
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
+                  const sorted = header.column.getIsSorted();
+                  const ariaSort = canSort
+                    ? sorted === "asc"
+                      ? "ascending"
+                      : sorted === "desc"
+                        ? "descending"
+                        : "none"
+                    : undefined;
                   return (
                     <th
                       key={header.id}
+                      scope="col"
+                      aria-sort={ariaSort}
                       className={cn(
                         "px-2 py-2 text-left",
                         "text-[length:var(--text-caption-size)] leading-[var(--text-caption-leading)]",
@@ -386,7 +398,7 @@ export function QueueList({
                           ? null
                           : flexRender(header.column.columnDef.header, header.getContext())}
                         {canSort && (
-                          <SortIcon direction={header.column.getIsSorted()} />
+                          <SortIcon direction={sorted} />
                         )}
                       </div>
                     </th>
@@ -438,6 +450,7 @@ export function QueueList({
             Export
           </Button>
           <select
+            aria-label="Items per page"
             className={cn(
               "h-7 rounded-[var(--radius-sm)] border border-border-default bg-bg-surface px-2",
               "text-[length:var(--text-caption-size)] text-fg-default",

--- a/src/components/patterns/QueueRow.tsx
+++ b/src/components/patterns/QueueRow.tsx
@@ -54,9 +54,17 @@ export const QueueRow = memo(function QueueRow({
         isSelected && "bg-accent-primary-subtle",
         isActive && !isSelected && "bg-bg-active",
         !isSelected && !isActive && "hover:bg-bg-hover",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-focus)] focus-visible:ring-inset",
       )}
+      tabIndex={0}
+      aria-label={`${row.title} — ${row.status}`}
+      aria-selected={isSelected}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") { e.preventDefault(); onClick(); }
+        if (e.key === " ") { e.preventDefault(); onSelect(); }
+      }}
       data-active={isActive || undefined}
     >
       {/* Selection checkbox */}


### PR DESCRIPTION
## Summary

- **AC1/AC3 — Table semantics**: `<table>` gets `aria-label="Queue items"`; all `<th>` get `scope="col"`; sortable headers get `aria-sort="ascending"/"descending"/"none"` so sort state is announced to screen readers
- **AC1 — Unlabelled controls**: Pagination `<select>` gets `aria-label="Items per page"`; ActivityTimeline filter toggle buttons get `aria-pressed={active}`
- **AC4 — Filter input labels**: `FilterBar`'s `DebouncedInput` accepts an `ariaLabel` prop threaded to the underlying `<input>`; owner input labelled "Filter by owner", search input labelled "Search queue items"
- **AC6 — Live regions**: Loading skeleton wrapped in `role="status" aria-live="polite"`; empty state wrapped in `role="status" aria-live="polite"` — screen readers announce when data is loading or results are empty
- **AC7/AC1 — Keyboard-operable rows**: `QueueRow <tr>` gets `tabIndex={0}` and `aria-label="{title} — {status}"`; `Enter` opens the preview, `Space` toggles checkbox selection; focus ring added via `focus-visible:ring-2`

**Already correct (no changes needed):**
- AC2: Skip-to-main link (`<a href="#main" className="skip-link">`) already in `AppShell`; `.skip-link` CSS already in `styles.css`; modals use Radix UI Dialog which provides focus trapping
- AC5: All status badges use both colour and text; `DueIndicator` uses labelled text ("4d overdue"), not colour alone
- AC8: `Input`/`Select` primitives already implement `aria-invalid` + `aria-describedby`

## Test plan

- [ ] Navigate the queue table with Tab + Enter/Space — each row is reachable, Enter opens preview, Space toggles selection
- [ ] Use a screen reader (VoiceOver/NVDA) — table is announced as "Queue items"; headers include scope; sort direction is announced when clicking sortable columns
- [ ] "Items per page" select is announced correctly by screen reader
- [ ] ActivityTimeline filter buttons announce "pressed" state
- [ ] Owner input announces "Filter by owner"; search announces "Search queue items"
- [ ] With screen reader active, filter by owner → screen reader announces "No items in queue" on empty result
- [ ] TypeScript: `npx tsc --noEmit` passes clean
- [ ] Production build: `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)