### PR TITLE
refactor(Q1-Q5): type safety, deduplicate queuePath, note validation

### DIFF
--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -10,6 +10,6 @@ export function executeAction(
 ): Promise<ActionResponse> {
   return frappeCall<ActionResponse>(
     "controldesk_core.api.run_operator_case_action",
-    params as unknown as Record<string, unknown>,
+    params,
   );
 }

--- a/src/api/bulk-actions.ts
+++ b/src/api/bulk-actions.ts
@@ -31,6 +31,6 @@ export function executeBulkAction(
 ): Promise<BulkActionResponse> {
   return frappeCall<BulkActionResponse>(
     "controldesk_core.api.run_bulk_operator_action",
-    params as unknown as Record<string, unknown>,
+    params,
   );
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -76,7 +76,7 @@ function sleep(ms: number): Promise<void> {
 
 async function doFetch(
   url: string,
-  params: Record<string, unknown>,
+  params: object,
   csrfToken: string,
 ): Promise<Response> {
   const controller = new AbortController();
@@ -143,7 +143,7 @@ async function parseSuccessBody<T>(res: Response, method: string): Promise<T> {
  */
 export async function frappeCall<T>(
   method: string,
-  params: Record<string, unknown> = {},
+  params: object = {},
 ): Promise<T> {
   const url = `${BASE_URL}/api/method/${method}`;
   let lastError: unknown;

--- a/src/components/patterns/CommandPalette.tsx
+++ b/src/components/patterns/CommandPalette.tsx
@@ -7,6 +7,7 @@ import { CommandItem } from "../composites/CommandItem";
 import { useCommandPaletteStore } from "../../stores/command-palette-store";
 import { useKeyboard } from "../../hooks/use-keyboard";
 import { QUEUE_CONFIG } from "../../config/queue-config";
+import { queuePath } from "../../config/routes";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -18,16 +19,6 @@ interface PaletteResult {
   description?: string;
   group: string;
   path: string;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-function queuePath(key: string): string {
-  if (key === "my_work") return "/work";
-  if (key === "intake_exceptions") return "/intake";
-  return `/queue/${key}`;
 }
 
 function buildQueueResults(): PaletteResult[] {

--- a/src/components/patterns/Sidebar.tsx
+++ b/src/components/patterns/Sidebar.tsx
@@ -8,18 +8,8 @@ import { QueueCounter } from "../composites/QueueCounter";
 import { useUIStore } from "../../stores/ui-store";
 import { useBootstrap } from "../../hooks/use-bootstrap";
 import { QUEUE_CONFIG, type QueueConfigEntry } from "../../config/queue-config";
+import { queuePath } from "../../config/routes";
 import type { QueueGroup } from "../../types/enums";
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-/** Map queue group to route prefix. Personal scopes use special paths. */
-function queuePath(entry: QueueConfigEntry): string {
-  if (entry.key === "my_work") return "/work";
-  if (entry.key === "intake_exceptions") return "/intake";
-  return `/queue/${entry.key}`;
-}
 
 const GROUP_LABELS: Record<QueueGroup, string> = {
   personal: "Personal Scopes",
@@ -81,7 +71,7 @@ const SidebarGroup = memo(function SidebarGroup({
             const item = (
               <NavLink
                 key={entry.key}
-                to={queuePath(entry)}
+                to={queuePath(entry.key)}
                 className="block"
               >
                 {({ isActive }) => (

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -43,6 +43,8 @@ export type RoutePath = (typeof ROUTE_PATHS)[keyof typeof ROUTE_PATHS];
 // ---------------------------------------------------------------------------
 
 export function queuePath(queueKey: string): string {
+  if (queueKey === "my_work") return "/work";
+  if (queueKey === "intake_exceptions") return "/intake";
   return `/queue/${queueKey}`;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,10 @@ const queryClient = new QueryClient({
   },
 });
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element #root not found in document");
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>

--- a/src/pages/CaseDetailPage.tsx
+++ b/src/pages/CaseDetailPage.tsx
@@ -22,6 +22,13 @@ import type {
 } from "../types/api";
 import { queuePath } from "../config/routes";
 
+/** Default SLA budget in minutes (8 hours). Override per-field when the
+ *  backend supplies a custom budget value. */
+const DEFAULT_SLA_BUDGET_MINUTES = 480;
+
+/** Maximum character length enforced on case notes before submission. */
+const MAX_NOTE_LENGTH = 5000;
+
 import { DetailHeader } from "../components/patterns/DetailHeader";
 import { DetailTabBar } from "../components/patterns/DetailTabBar";
 import { ActivityTimeline } from "../components/patterns/ActivityTimeline";
@@ -278,8 +285,8 @@ function OverviewTab({
                   key={f.key}
                   label={f.label}
                   elapsed={elapsed}
-                  budget={480}
-                  breached={elapsed > 480}
+                  budget={DEFAULT_SLA_BUDGET_MINUTES}
+                  breached={elapsed > DEFAULT_SLA_BUDGET_MINUTES}
                   className="mb-2 last:mb-0"
                 />
               );
@@ -327,8 +334,10 @@ function OverviewTab({
           <textarea
             placeholder="Add a note..."
             rows={2}
+            maxLength={MAX_NOTE_LENGTH}
             value={noteText}
             onChange={(e) => onNoteTextChange(e.target.value)}
+            aria-label="Note text"
             className={cn(
               "w-full rounded-[var(--radius-md)] border border-border-default bg-bg-surface px-3 py-2",
               "text-[length:var(--text-small-size)] text-fg-default placeholder:text-fg-faint",


### PR DESCRIPTION
## Summary

- **Q1** – Remove unsafe `as unknown as Record<string,unknown>` double-casts from `actions.ts` / `bulk-actions.ts` by widening `frappeCall` / `doFetch` params to `object`
- **Q2** – Replace non-null assertion (`!`) on `document.getElementById("root")` in `main.tsx` with an explicit runtime guard that throws a descriptive error
- **Q3** – Consolidate three duplicate `queuePath` implementations (routes.ts, Sidebar.tsx, CommandPalette.tsx) into the single canonical export in `config/routes.ts`; Sidebar and CommandPalette now import from there
- **Q4** – Extract magic number `480` into `DEFAULT_SLA_BUDGET_MINUTES` constant in `CaseDetailPage.tsx` with an 8-hour comment
- **Q5** – Add `maxLength={5000}` and `aria-label` to the case note textarea

## Test plan

- [ ] `npm run build` — no type errors
- [ ] Queue navigation via sidebar and command palette routes correctly for `my_work`, `intake_exceptions`, and generic queues
- [ ] Note textarea enforces 5000-char limit
- [ ] SLA meters render correctly in case detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)