### PR TITLE
feat(O1-O5): page-level error boundaries, richer schema errors, auth logging

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,7 @@
 // Base Frappe RPC client
 // ---------------------------------------------------------------------------
 
+import { z } from "zod";
 import { getCsrfToken, fetchCsrfToken } from "../lib/auth";
 import type { FrappeResponse } from "../types/api";
 
@@ -41,7 +42,15 @@ export class ApiSchemaError extends Error {
     method: string,
     public cause: unknown,
   ) {
-    super(`Unexpected response shape from ${method}`);
+    const detail =
+      cause instanceof z.ZodError
+        ? ": " +
+          cause.issues
+            .slice(0, 3)
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("; ")
+        : "";
+    super(`Unexpected response shape from ${method}${detail}`);
     this.name = "ApiSchemaError";
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,9 +58,10 @@ export async function logout(): Promise<void> {
       "X-Frappe-CSRF-Token": getCsrfToken(),
     },
     credentials: "include",
-  }).catch(() => {
+  }).catch((err: unknown) => {
     // Best-effort — even if the network call fails, the client-side
     // cleanup below will run so the user is redirected to login.
+    console.warn("[auth] Logout request failed (session may still be active on server):", err);
   });
 }
 
@@ -109,9 +110,10 @@ export async function fetchCsrfToken(): Promise<string> {
       _csrfToken = match[1];
       return _csrfToken;
     }
-  } catch {
+  } catch (err) {
     // Non-fatal — requests will proceed without CSRF header and the backend
     // will reject them with 403 if it requires the token, triggering a retry.
+    console.warn("[auth] CSRF token fetch failed:", err);
   }
   return _csrfToken;
 }

--- a/src/pages/QueueWorkbenchPage.tsx
+++ b/src/pages/QueueWorkbenchPage.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/cn";
 import { useUIStore } from "../stores/ui-store";
 import { useKeyboard } from "../hooks/use-keyboard";
 import { useUrlFilters } from "../hooks/use-url-filters";
+import { ErrorBoundary } from "../ui/ErrorBoundary";
 import { FilterBar } from "../components/patterns/FilterBar";
 import { QueueList } from "../components/patterns/QueueList";
 const PreviewPanel = lazy(() =>
@@ -134,17 +135,20 @@ export default function QueueWorkbenchPage() {
         </div>
       </div>
 
-      {/* Preview panel — lazy-loaded so it doesn't land in the initial bundle */}
+      {/* Preview panel — lazy-loaded; ErrorBoundary ensures a load failure
+          doesn't crash the workbench, just collapses the panel gracefully */}
       {previewOpen && selectedRowId && previewDoctype && (
-        <Suspense fallback={null}>
-          <PreviewPanel
-            doctype={previewDoctype}
-            docname={selectedRowId}
-            queueKey={queueKey}
-            onClose={handleClosePreview}
-            onOpenDetail={handleOpenDetail}
-          />
-        </Suspense>
+        <ErrorBoundary inline>
+          <Suspense fallback={null}>
+            <PreviewPanel
+              doctype={previewDoctype}
+              docname={selectedRowId}
+              queueKey={queueKey}
+              onClose={handleClosePreview}
+              onOpenDetail={handleOpenDetail}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
     </div>
   );

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from "../components/patterns/CommandPalette";
 import { ShortcutsModal } from "../components/patterns/ShortcutsModal";
 import { Spinner } from "../components/primitives/Spinner";
 import { Button } from "../components/primitives/Button";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { useUIStore } from "../stores/ui-store";
 import { useKeyboard } from "../hooks/use-keyboard";
 import { useAuthCheck, AuthServiceUnavailableError } from "../hooks/use-auth-check";
@@ -112,9 +113,11 @@ export function AppShell() {
                   : "ml-[var(--sidebar-width)]",
               )}
             >
-              <Suspense fallback={<PageFallback />}>
-                <Outlet />
-              </Suspense>
+              <ErrorBoundary inline>
+                <Suspense fallback={<PageFallback />}>
+                  <Outlet />
+                </Suspense>
+              </ErrorBoundary>
             </main>
           </div>
 

--- a/src/ui/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary.tsx
@@ -3,6 +3,9 @@ import { AlertTriangle, RotateCcw } from "lucide-react";
 
 interface Props {
   children: ReactNode;
+  /** When true, renders a compact error banner instead of a full-screen takeover.
+   *  Use this for page/section-level boundaries so the shell (nav, sidebar) stays visible. */
+  inline?: boolean;
 }
 
 interface State {
@@ -26,6 +29,25 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      if (this.props.inline) {
+        return (
+          <div className="flex h-[50vh] flex-col items-center justify-center gap-3 px-6 text-center">
+            <AlertTriangle size={32} className="text-status-warning" aria-hidden />
+            <p className="max-w-sm text-sm text-fg-muted">
+              {this.state.error?.message || "This page could not be loaded."}
+            </p>
+            <button
+              type="button"
+              onClick={this.handleReset}
+              className="inline-flex items-center gap-2 rounded-lg border border-border-default bg-bg-surface px-3 py-1.5 text-sm font-medium text-fg-default hover:bg-bg-surface-hover transition-colors cursor-pointer"
+            >
+              <RotateCcw size={14} aria-hidden />
+              Try again
+            </button>
+          </div>
+        );
+      }
+
       return (
         <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-bg-app px-6 text-center">
           <AlertTriangle size={48} className="text-status-warning" aria-hidden />


### PR DESCRIPTION
## Summary

- **O1** – `ErrorBoundary`: add `inline` prop for contained page-level error UI; `AppShell` now wraps `<Outlet>` in `<ErrorBoundary inline>` so a render crash in one page keeps the shell (nav, sidebar) intact
- **O2** – `QueueWorkbenchPage`: wrap lazy `PreviewPanel` in `<ErrorBoundary inline>` so a chunk-load failure collapses the panel gracefully instead of crashing the workbench
- **O3** – `api/client`: `ApiSchemaError` now embeds the first 3 Zod issue paths + messages in the error string, making schema mismatches immediately actionable in devtools / error reporting
- **O4** – `lib/auth`: CSRF token fetch failure emits `console.warn` with the error, surfacing silent 403 root causes
- **O5** – `lib/auth`: Logout network failure emits `console.warn` noting that the server-side session may still be active

## Test plan

- [ ] `npm run build` — clean
- [ ] Throw a deliberate render error in a page component → expect inline error banner, nav/sidebar stay visible; "Try again" resets
- [ ] Simulate chunk load failure for PreviewPanel → expect graceful panel collapse
- [ ] Trigger a Zod schema mismatch → error message includes field paths
- [ ] Network offline during logout → console.warn appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)