### PR TITLE
feat(M1-M5): responsive layout for filters, table columns, panel, modals

### DIFF
--- a/src/components/patterns/CommandPalette.tsx
+++ b/src/components/patterns/CommandPalette.tsx
@@ -160,7 +160,7 @@ export function CommandPalette() {
           className={cn(
             "fixed left-1/2 top-[20%] z-[var(--z-command-palette)]",
             "-translate-x-1/2",
-            "w-full max-w-[560px]",
+            "w-[calc(100vw-2rem)] sm:w-full max-w-[560px]",
             "rounded-[var(--radius-xl)] border border-border-default",
             "bg-bg-surface-raised shadow-lg",
             "flex flex-col overflow-hidden",

--- a/src/components/patterns/FilterBar.tsx
+++ b/src/components/patterns/FilterBar.tsx
@@ -158,7 +158,7 @@ export function FilterBar({
             onValueChange={(v) =>
               onFiltersChange({ ...filters, status: v || undefined })
             }
-            className="w-[140px]"
+            className="w-full sm:w-[140px]"
           />
         )}
 
@@ -173,7 +173,7 @@ export function FilterBar({
               escalation_state: (v as EscalationState) || undefined,
             })
           }
-          className="w-[140px]"
+          className="w-full sm:w-[140px]"
         />
 
         {/* Owner filter — debounced text search */}
@@ -183,7 +183,7 @@ export function FilterBar({
           onCommit={handleOwner}
           placeholder="Owner..."
           ariaLabel="Filter by owner"
-          className="w-[150px]"
+          className="w-full sm:w-[150px]"
         />
 
         {/* Overdue toggle */}
@@ -220,7 +220,7 @@ export function FilterBar({
           onCommit={handleSearch}
           placeholder="Search..."
           ariaLabel="Search queue items"
-          className="w-[200px]"
+          className="w-full sm:w-[200px]"
           icon={Search}
         />
 

--- a/src/components/patterns/PreviewPanel.tsx
+++ b/src/components/patterns/PreviewPanel.tsx
@@ -167,7 +167,8 @@ export function PreviewPanel({
     <aside
       className={cn(
         "fixed top-[var(--topbar-height,56px)] right-0 bottom-0",
-        "w-[var(--preview-panel-width,420px)]",
+        // Full-width on mobile; fixed panel width on sm and up
+        "w-full sm:w-[var(--preview-panel-width,420px)]",
         "border-l border-border-default",
         "bg-bg-surface",
         "overflow-y-auto",

--- a/src/components/patterns/QueueList.tsx
+++ b/src/components/patterns/QueueList.tsx
@@ -412,6 +412,10 @@ export function QueueList({
                         "font-[number:var(--text-caption-medium-weight)]",
                         "text-fg-muted",
                         canSort && "cursor-pointer select-none hover:text-fg-default",
+                        // Mirror the responsive visibility of matching <td> cells in QueueRow
+                        header.column.id === "context" && "hidden lg:table-cell",
+                        header.column.id === "current_owner" && "hidden md:table-cell",
+                        header.column.id === "target_date" && "hidden md:table-cell",
                       )}
                       style={{ width: header.getSize() }}
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}

--- a/src/components/patterns/QueueRow.tsx
+++ b/src/components/patterns/QueueRow.tsx
@@ -118,8 +118,8 @@ export const QueueRow = memo(function QueueRow({
         </div>
       </td>
 
-      {/* Property / Unit context */}
-      <td className="w-[160px] px-2">
+      {/* Property / Unit context — hidden on small screens */}
+      <td className="hidden lg:table-cell w-[160px] px-2">
         <span
           className={cn(
             "block truncate",
@@ -141,13 +141,13 @@ export const QueueRow = memo(function QueueRow({
         />
       </td>
 
-      {/* Owner */}
-      <td className="w-[120px] px-2">
+      {/* Owner — hidden on small screens */}
+      <td className="hidden md:table-cell w-[120px] px-2">
         <OwnerChip owner={row.current_owner} />
       </td>
 
-      {/* Due */}
-      <td className="w-[100px] px-2">
+      {/* Due — hidden on small screens */}
+      <td className="hidden md:table-cell w-[100px] px-2">
         <DueIndicator
           targetDate={row.target_date}
           isOverdue={row.is_overdue || row.overdue}

--- a/src/components/patterns/ShortcutsModal.tsx
+++ b/src/components/patterns/ShortcutsModal.tsx
@@ -88,7 +88,7 @@ export function ShortcutsModal({ open, onOpenChange }: ShortcutsModalProps) {
         <Dialog.Content
           className={cn(
             "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
-            "w-full max-w-lg max-h-[80vh]",
+            "w-[calc(100vw-2rem)] sm:w-full max-w-lg max-h-[80vh]",
             "bg-bg-default border border-border-default",
             "rounded-[var(--radius-lg)] shadow-lg",
             "flex flex-col",

--- a/src/pages/QueueWorkbenchPage.tsx
+++ b/src/pages/QueueWorkbenchPage.tsx
@@ -109,7 +109,8 @@ export default function QueueWorkbenchPage() {
         className={cn(
           "flex flex-1 flex-col min-w-0",
           "transition-[margin] duration-[var(--duration-normal,200ms)]",
-          previewOpen && "mr-[var(--preview-panel-width,420px)]",
+          // On mobile the panel overlays full-width; only shift content on sm+
+          previewOpen && "sm:mr-[var(--preview-panel-width,420px)]",
         )}
       >
         {/* Filter bar */}


### PR DESCRIPTION
## Summary

- **M1** – `FilterBar`: filter selects and text inputs expand to `w-full` on mobile, fixed widths on `sm+` — no more horizontal overflow on narrow screens
- **M2** – `QueueRow` / `QueueList`: hide Property/Unit column at `lg+`, Owner and Due columns at `md+`; `<th>` header cells get matching visibility classes to stay in sync
- **M3** – `PreviewPanel`: `w-full` on mobile (full-screen overlay), `w-[--preview-panel-width]` on `sm+`; `QueueWorkbenchPage` only applies the 420px content margin on `sm+`
- **M4** – `ShortcutsModal` / `CommandPalette`: dialog containers use `w-[calc(100vw-2rem)]` on mobile with `sm:w-full max-w-*` fallback to prevent viewport overflow

## Test plan

- [ ] `npm run build` — clean
- [ ] At 375px width: FilterBar controls stack/wrap, table shows only Select/Queue/Title/Status/Signals, PreviewPanel covers full screen
- [ ] At 768px (tablet): Owner and Due columns appear; panel shifts content correctly
- [ ] Command palette and shortcuts modal stay within viewport on mobile
- [ ] Desktop layout unchanged at 1280px+

🤖 Generated with [Claude Code](https://claude.com/claude-code)