### PR TITLE
fix(settings): accessibility, mobile, and sign-out hardening (U1-U5)

### DIFF
--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import SettingsPage from "./SettingsPage";
+
+/* ------------------------------------------------------------------ */
+/*  Module mocks                                                        */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../hooks/use-theme", () => ({
+  useTheme: () => ({ theme: "system", setTheme: vi.fn(), resolvedTheme: "light" }),
+}));
+
+vi.mock("../stores/ui-store", () => ({
+  useUIStore: () => ({
+    rowDensity: "comfortable",
+    setRowDensity: vi.fn(),
+    sidebarCollapsed: false,
+    toggleSidebar: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/use-role-gate", () => ({
+  useRoleGate: () => ({ userRoles: ["Operator", "Manager"] }),
+}));
+
+vi.mock("../hooks/use-auth-check", () => ({
+  useAuthCheck: () => ({ data: "operator@controldesk.local" }),
+  AuthServiceUnavailableError: class AuthServiceUnavailableError extends Error {},
+}));
+
+vi.mock("../lib/auth", () => ({
+  logout: vi.fn().mockResolvedValue(undefined),
+  clearCsrfToken: vi.fn(),
+}));
+
+/* ------------------------------------------------------------------ */
+/*  Test wrapper                                                        */
+/* ------------------------------------------------------------------ */
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("SettingsPage", () => {
+  it("renders the Appearance, Keyboard Shortcuts, and Account sections", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("shows the current user email in the Account section", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    expect(screen.getByText("operator@controldesk.local")).toBeInTheDocument();
+  });
+
+  it("renders all three theme options in a radiogroup", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    const radiogroup = screen.getByRole("radiogroup", { name: "Theme" });
+    expect(radiogroup).toBeInTheDocument();
+
+    expect(screen.getByRole("radio", { name: /System/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Light/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Dark/i })).toBeInTheDocument();
+  });
+
+  it("marks the current theme option as checked", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    expect(screen.getByRole("radio", { name: /System/i })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("radio", { name: /Light/i })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("displays user roles as badges", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    expect(screen.getByText("Operator")).toBeInTheDocument();
+    expect(screen.getByText("Manager")).toBeInTheDocument();
+  });
+
+  it("renders the keyboard shortcuts table with proper column headers", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    const ths = screen
+      .getAllByRole("columnheader")
+      .filter((th) => th.getAttribute("scope") === "col");
+    expect(ths).toHaveLength(3);
+    expect(ths[0]).toHaveTextContent("Key");
+    expect(ths[1]).toHaveTextContent("Description");
+    expect(ths[2]).toHaveTextContent("Scope");
+  });
+
+  it("renders a Sign out button", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    expect(screen.getByRole("button", { name: /Sign out/i })).toBeInTheDocument();
+  });
+
+  it("disables the Sign out button while signing out", () => {
+    render(<SettingsPage />, { wrapper: Wrapper });
+
+    const btn = screen.getByRole("button", { name: /Sign out/i });
+    fireEvent.click(btn);
+
+    // After click the button becomes disabled while the async sign-out runs
+    expect(btn).toBeDisabled();
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -127,6 +127,7 @@ export default function SettingsPage() {
     } finally {
       // Always clean up client-side state, even if the network call failed
       clearCsrfToken();
+      await queryClient.cancelQueries();
       queryClient.clear();
       navigate("/login", { replace: true });
     }
@@ -155,10 +156,10 @@ export default function SettingsPage() {
           <div className="space-y-5">
             {/* Theme selector */}
             <div>
-              <label className="text-[length:var(--text-small-size)] font-medium text-fg-default block mb-2">
+              <label id="theme-label" className="text-[length:var(--text-small-size)] font-medium text-fg-default block mb-2">
                 Theme
               </label>
-              <div className="flex gap-2" role="radiogroup" aria-label="Theme">
+              <div className="flex flex-wrap gap-2" role="radiogroup" aria-labelledby="theme-label">
                 {THEME_OPTIONS.map((opt) => (
                   <ThemeOption
                     key={opt.value}
@@ -216,13 +217,13 @@ export default function SettingsPage() {
             <table className="w-full text-left">
               <thead>
                 <tr className="border-b border-border-default">
-                  <th className="pb-2 pr-4 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
+                  <th scope="col" className="pb-2 pr-4 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
                     Key
                   </th>
-                  <th className="pb-2 pr-4 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
+                  <th scope="col" className="pb-2 pr-4 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
                     Description
                   </th>
-                  <th className="pb-2 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
+                  <th scope="col" className="pb-2 text-[length:var(--text-caption-size)] font-[number:var(--text-body-medium-weight)] text-fg-muted">
                     Scope
                   </th>
                 </tr>


### PR DESCRIPTION
## Summary
- **U1** – Add `scope="col"` to all three `<th>` elements in the keyboard shortcuts table so screen readers can associate headers with data cells
- **U2** – Replace `aria-label="Theme"` string on the radiogroup with `aria-labelledby` pointing to the visible label element
- **U3** – Add `flex-wrap` to the theme radiogroup so the System / Light / Dark buttons stack gracefully on narrow viewports
- **U4** – `await queryClient.cancelQueries()` before `queryClient.clear()` in the sign-out handler to abort any in-flight requests before wiping the cache
- **U5** – Add `src/pages/SettingsPage.test.tsx` with 8 smoke tests covering: section rendering, user email display, theme radiogroup ARIA, role badges, `scope="col"` column headers, sign-out button presence and disabled state

## Test plan
- [ ] All 72 unit tests pass (`npx vitest run`)
- [ ] TypeScript check clean (`npx tsc --noEmit`)
- [ ] Production build succeeds (`npm run build`)
- [ ] Manual: Settings page renders correctly at all viewport widths
- [ ] Manual: Theme buttons wrap on narrow mobile widths instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)