### PR TITLE
fix: case-insensitive onboarding check for document collection button

### DIFF
--- a/src/pages/CaseDetailPage.tsx
+++ b/src/pages/CaseDetailPage.tsx
@@ -438,10 +438,12 @@ function DocumentsTab({
   const hasContent =
     docSections.length > 0 || sigSections.length > 0 || docFields.length > 0;
 
+  const isOnboarding = lifecycle?.toLowerCase().includes("onboarding") ?? false;
+
   if (!hasContent) {
     return (
       <div className="space-y-4">
-        {lifecycle === "onboarding" && (
+        {isOnboarding && (
           <div className="flex justify-start">
             <Button
               variant="secondary"
@@ -464,7 +466,7 @@ function DocumentsTab({
 
   return (
     <div className="space-y-4">
-      {lifecycle === "onboarding" && (
+      {isOnboarding && (
         <div className="flex justify-start">
           <Button
             variant="secondary"

--- a/src/pages/InspectionDetailPage.tsx
+++ b/src/pages/InspectionDetailPage.tsx
@@ -55,7 +55,7 @@ const TYPE_CONFIG: Record<string, { label: string; className: string }> = {
   },
   move_out: {
     label: "Move Out",
-    className: "bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20",
+    className: "bg-orange-50 text-orange-700 border-orange-200",
   },
   periodic: {
     label: "Periodic",
@@ -82,7 +82,7 @@ const CONDITION_CONFIG: Record<string, { label: string; className: string }> = {
   },
   poor: {
     label: "Poor",
-    className: "bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20",
+    className: "bg-orange-50 text-orange-700 border-orange-200",
   },
   unacceptable: {
     label: "Unacceptable",
@@ -614,7 +614,7 @@ export default function InspectionDetailPage() {
                 <Badge className={typeConfig.className}>{typeConfig.label}</Badge>
                 <StatusBadge status={data.status} />
                 {data.make_good_required && (
-                  <Badge className="bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20">
+                  <Badge className="bg-orange-50 text-orange-700 border-orange-200">
                     Make Good Required
                   </Badge>
                 )}

--- a/src/pages/InspectionDetailPage.tsx
+++ b/src/pages/InspectionDetailPage.tsx
@@ -55,7 +55,7 @@ const TYPE_CONFIG: Record<string, { label: string; className: string }> = {
   },
   move_out: {
     label: "Move Out",
-    className: "bg-orange-50 text-orange-700 border-orange-200",
+    className: "bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20",
   },
   periodic: {
     label: "Periodic",
@@ -82,7 +82,7 @@ const CONDITION_CONFIG: Record<string, { label: string; className: string }> = {
   },
   poor: {
     label: "Poor",
-    className: "bg-orange-50 text-orange-700 border-orange-200",
+    className: "bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20",
   },
   unacceptable: {
     label: "Unacceptable",
@@ -614,7 +614,7 @@ export default function InspectionDetailPage() {
                 <Badge className={typeConfig.className}>{typeConfig.label}</Badge>
                 <StatusBadge status={data.status} />
                 {data.make_good_required && (
-                  <Badge className="bg-orange-50 text-orange-700 border-orange-200">
+                  <Badge className="bg-[#FFF3E0] text-[#E65100] border-[#E65100]/20">
                     Make Good Required
                   </Badge>
                 )}


### PR DESCRIPTION
## Summary
- `lifecycle` from `useParams` is `"Onboarding Case"`, not `"onboarding"` — the strict equality check in DocumentsTab never matched, so the Start Document Collection button was never rendered
- Changed to `lifecycle?.toLowerCase().includes("onboarding")` to handle the actual caseType value

## Test plan
- [ ] Navigate to an onboarding case detail → Documents tab shows "Start Document Collection" button
- [ ] Navigate to a non-onboarding case detail → Documents tab does NOT show the button
- [ ] `npm test -- --run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)